### PR TITLE
CORE-8162 Remove job stats columns from app_listing view.

### DIFF
--- a/src/main/conversions/v2.9.0/c290_2016100701.clj
+++ b/src/main/conversions/v2.9.0/c290_2016100701.clj
@@ -14,15 +14,8 @@
   (exec-sql-statement "CREATE INDEX jobs_start_date_index ON jobs(start_date)")
   (exec-sql-statement "CREATE INDEX jobs_end_date_index ON jobs(end_date)"))
 
-(defn- update-app-listing-view
-  "Updates the app_listing view."
-  []
-  (println "\t* updating the app_listing view...")
-  (load-sql-file "views/03_app_listing.sql"))
-
 (defn convert
   "Performs the conversion for this database version"
   []
   (println "Performing the conversion for" version)
-  (add-jobs-indexes)
-  (update-app-listing-view))
+  (add-jobs-indexes))

--- a/src/main/views/03_app_listing.sql
+++ b/src/main/views/03_app_listing.sql
@@ -41,29 +41,11 @@ CREATE OR REPLACE VIEW app_listing AS
                 ELSE MAX(tt.name)
            END AS overall_job_type,
            integration.user_id AS integrator_id,
-           u.username AS integrator_username,
-           COUNT(j.id) AS job_count,
-           MAX(j.start_date) AS last_used,
-           (   SELECT COUNT(id)
-               FROM jobs
-               WHERE apps.id::varchar = app_id
-                     AND status = 'Completed'
-           ) AS job_count_completed,
-           (   SELECT COUNT(id)
-               FROM jobs
-               WHERE apps.id::varchar = app_id
-                     AND status = 'Failed'
-           ) AS job_count_failed,
-           (   SELECT MAX(end_date)
-               FROM jobs
-               WHERE apps.id::varchar = app_id
-                     AND status = 'Completed'
-           ) AS job_last_completed
+           u.username AS integrator_username
     FROM apps
          LEFT JOIN integration_data integration ON apps.integration_data_id = integration.id
          LEFT JOIN users u ON integration.user_id = u.id
          LEFT JOIN app_steps steps ON apps.id = steps.app_id
-         LEFT JOIN jobs j ON apps.id::varchar = j.app_id
          LEFT JOIN tasks t ON steps.task_id = t.id
          LEFT JOIN tools tool ON t.tool_id = tool.id
          LEFT JOIN tool_types tt ON tool.tool_type_id = tt.id


### PR DESCRIPTION
These job stat joins and subselects significantly slowed down queries against this view when tested against production data copied from the `jobs` table into our dev environments. For example:

`/apps/categories`: Category listing (workspace navigation panel)
- before ~2.5 seconds
- after ~10 seconds

`/apps/categories/{category-id}`: Apps listing in workspace categories
- before ~0.5 seconds
- after ~6 seconds

`/apps/hierarchies/{root-iri}/apps`: Apps listing in ontology hierarchies
- before ~1 second
- after ~4 seconds

`/apps`: App search
- before ~0.6 seconds
- after ~13 seconds

So these job stats will only be looked-up in separate queries, and only in apps details or admin listing endpoints.
