### PR TITLE
CORE-8455: add a docker_registries table to store registry-level authentication information

### DIFF
--- a/src/main/constraints/00_77_docker_registries_pkey.sql
+++ b/src/main/constraints/00_77_docker_registries_pkey.sql
@@ -1,0 +1,8 @@
+SET search_path = public, pg_catalog;
+
+--
+-- Primary key constraint for the docker_registries table.
+--
+ALTER TABLE ONLY docker_registries
+    ADD CONSTRAINT docker_registries_pkey
+    PRIMARY KEY(name);

--- a/src/main/conversions/v2.10.0/c2_10_0_2016120101.clj
+++ b/src/main/conversions/v2.10.0/c2_10_0_2016120101.clj
@@ -1,0 +1,19 @@
+(ns facepalm.c2-10-0-2016120101
+    (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.10.0:20161201.01")
+
+(defn- add-docker-registries-table
+  "Adds the docker_registries table"
+  []
+  (println "\t* adding docker_registries table...")
+  (load-sql-file "tables/77_docker_registries.sql")
+  (load-sql-file "constraints/00_77_docker_registries_pkey.sql"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-docker-registries-table))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -80,3 +80,4 @@ INSERT INTO version (version) VALUES ('2.7.0:20160614.01');
 INSERT INTO version (version) VALUES ('2.8.0:20160712.01');
 INSERT INTO version (version) VALUES ('2.8.0:20160728.01');
 INSERT INTO version (version) VALUES ('2.9.0:20161007.01');
+INSERT INTO version (version) VALUES ('2.10.0:20161201.01');

--- a/src/main/tables/77_docker_registries.sql
+++ b/src/main/tables/77_docker_registries.sql
@@ -1,0 +1,10 @@
+SET search_path = public, pg_catalog;
+
+--
+-- Contains details about docker registries & authentication information
+--
+CREATE TABLE docker_registries (
+  name text NOT NULL, -- PRIMARY KEY; name of the registry; for image names with a slash or several in them, this is everything up to the last slash. For images without a slash, the registry "" is assumed (though this should need no authentication information)
+  username text NOT NULL, -- username to use with this registry
+  password text NOT NULL -- password to use with this registry
+);


### PR DESCRIPTION
This depends on the changes in cyverse-de/facepalm#4 but is otherwise currently unused by anything. (cyverse-de/apps and other PRs will come next)