### PR TITLE
Add conversion to move gims -> docker.cyverse.org

### DIFF
--- a/src/main/conversions/v2.10.0/c2_10_0_2016121401.clj
+++ b/src/main/conversions/v2.10.0/c2_10_0_2016121401.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-10-0-2016121401
+  (:require [korma.core :as sql]))
+
+(def ^:private version
+  "The destination database version"
+  "2.10.0:20161214.01")
+
+(defn- move-to-docker-cyverse-org
+  "Changes gims images to docker.cyverse.org images"
+  []
+  (println "\t* change gims.iplantcollaborative.org:5000 to docker.cyverse.org...")
+  (sql/exec-raw "UPDATE container_images SET name = regexp_replace(name, 'gims.iplantcollaborative.org:5000', 'docker.cyverse.org') WHERE name LIKE '%gims.iplantcollaborative.org:5000%'"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (move-to-docker-cyverse-org))


### PR DESCRIPTION
I've got the proxy set up and the credentials to use it in prod (not that prod uses it yet). Test jobs in dev worked nicely (even some on ad-hoc nodes, though I had to still do firewall tweaks to get that to work).