### PR TITLE
CORE-8745 Add conversion to make tools name+version unique.

### DIFF
--- a/src/main/constraints/03_tools.sql
+++ b/src/main/constraints/03_tools.sql
@@ -17,3 +17,10 @@ ALTER TABLE ONLY tools
     ADD CONSTRAINT tools_container_image_fkey
     FOREIGN KEY(container_images_id)
     REFERENCES container_images(id);
+
+--
+-- tools table unique constraint.
+--
+ALTER TABLE ONLY tools
+    ADD CONSTRAINT tools_unique
+    UNIQUE (name,version);

--- a/src/main/conversions/v2.12.0/c2_12_0_2017042801.clj
+++ b/src/main/conversions/v2.12.0/c2_12_0_2017042801.clj
@@ -1,0 +1,21 @@
+(ns facepalm.c2-12-0-2017042801
+  (:require [korma.core :as sql]))
+
+(def ^:private version
+  "The destination database version"
+  "2.12.0:20170428.01")
+
+(defn- make-tools-name-version-unique
+  []
+  (println "\t* make tools.version required and tools name+version unique...")
+  (sql/update :tools
+              (sql/set-fields {:version ""})
+              (sql/where {:version [= nil]}))
+  (sql/exec-raw "ALTER TABLE ONLY tools ALTER COLUMN version SET NOT NULL")
+  (sql/exec-raw "ALTER TABLE ONLY tools ADD CONSTRAINT tools_unique UNIQUE (name,version)"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (make-tools-name-version-unique))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -82,3 +82,4 @@ INSERT INTO version (version) VALUES ('2.8.0:20160728.01');
 INSERT INTO version (version) VALUES ('2.9.0:20161007.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161201.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161205.01');
+INSERT INTO version (version) VALUES ('2.12.0:20170428.01');

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -82,4 +82,5 @@ INSERT INTO version (version) VALUES ('2.8.0:20160728.01');
 INSERT INTO version (version) VALUES ('2.9.0:20161007.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161201.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161205.01');
+INSERT INTO version (version) VALUES ('2.10.0:20161214.01');
 INSERT INTO version (version) VALUES ('2.12.0:20170428.01');

--- a/src/main/tables/03_tools.sql
+++ b/src/main/tables/03_tools.sql
@@ -9,7 +9,7 @@ CREATE TABLE tools (
     location character varying(255),
     tool_type_id uuid NOT NULL,
     description text,
-    version character varying(255),
+    version character varying(255) NOT NULL,
     attribution text,
     integration_data_id uuid NOT NULL,
     container_images_id uuid,


### PR DESCRIPTION
Adds conversion `2.12.0:20170428.01` to make the `tools` table not allow NULL `version` values, and adds a `unique` constraint on the `name` and `version` columns.