### PR TITLE
Add resource restriction columns to container_settings

### DIFF
--- a/src/main/conversions/v2.12.0/c2_12_0_2017050801.clj
+++ b/src/main/conversions/v2.12.0/c2_12_0_2017050801.clj
@@ -1,0 +1,29 @@
+(ns facepalm.c2-12-0-2017050801
+  (:require [korma.core :as sql]))
+
+(def ^:private version
+  "The destination database version"
+  "2.12.0:20170508.01")
+
+(defn- add-min-memory-limit-column
+  []
+  (println "\t* add the container_settings.min_memory_limit column")
+  (sql/exec-raw "ALTER TABLE ONLY container_settings ADD COLUMN min_memory_limit bigint"))
+
+(defn- add-min-cpu-cores
+  []
+  (println "\t* add the container_settings.min_cpu_cores column")
+  (sql/exec-raw "ALTER TABLE ONLY container_settings ADD COLUMN min_cpu_cores integer"))
+
+(defn- add-min-disk-space
+  []
+  (println "\t* add the container_settings.min_disk_space column")
+  (sql/exec-raw "ALTER TABLE ONLY container_settings ADD COLUMN min_disk_space bigint"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-min-memory-limit-column)
+  (add-min-cpu-cores)
+  (add-min-disk-space))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -84,3 +84,4 @@ INSERT INTO version (version) VALUES ('2.10.0:20161201.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161205.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161214.01');
 INSERT INTO version (version) VALUES ('2.12.0:20170428.01');
+INSERT INTO version (version) VALUES ('2.12.0:20170508.01');

--- a/src/main/tables/71_container_settings.sql
+++ b/src/main/tables/71_container_settings.sql
@@ -26,7 +26,7 @@ CREATE TABLE container_settings (
   -- to Docker with the --cpus command-line switch.
   min_cpu_cores integer,
 
-  -- The minimum about of disk space required to run the container. This does
+  -- The minimum amount of disk space required to run the container. This does
   -- not correspond to a docker option, it's purely used for Condor job
   -- matching with ClassAds.
   min_disk_space bigint,

--- a/src/main/tables/71_container_settings.sql
+++ b/src/main/tables/71_container_settings.sql
@@ -15,9 +15,21 @@ CREATE TABLE container_settings (
   -- The 'shares' of the CPU that the container owns.
   cpu_shares integer,
 
-  -- The number of bytes to limit RAM to. integer isn't big enough, though
-  -- bigint is overkill.
+  -- The maximum RAM usage limit, in bytes.
   memory_limit bigint,
+
+  -- The minimum number of bytes required to run the container. This is used
+  -- in the Condor ClassAds and is not passed to the Docker container.
+  min_memory_limit bigint,
+
+  -- The minimum number of cpu cores required to run the container. It's passed
+  -- to Docker with the --cpus command-line switch.
+  min_cpu_cores integer,
+
+  -- The minimum about of disk space required to run the container. This does
+  -- not correspond to a docker option, it's purely used for Condor job
+  -- matching with ClassAds.
+  min_disk_space bigint,
 
   -- Most likely going to be 'bridge' or 'none', but may be set to a container
   -- id which is why we're using text.


### PR DESCRIPTION
Added the min_memory_limit column. Tracked in JIRA as CORE-8657.

Added the min_cpu_cores column. Tracked in JIRA as CORE-8658.

Added the min_disk_space column. Tracked in JIRA as CORE-8659.

The conversion was tested against a unittest-dedb container.
