### PR TITLE
CORE-8750 Add `deprecated` flag to `container_images` table.

### DIFF
--- a/src/main/conversions/v2.12.0/c2_12_0_2017051001.clj
+++ b/src/main/conversions/v2.12.0/c2_12_0_2017051001.clj
@@ -12,7 +12,7 @@
   (exec-sql-statement "ALTER TABLE ONLY container_images ADD COLUMN deprecated BOOLEAN NOT NULL DEFAULT FALSE")
   (sql/update :container_images
               (sql/set-fields {:deprecated true})
-              (sql/where {:name "docker.cyverse.org/backwards-compat"})))
+              (sql/where {:name [like "%/backwards-compat"]})))
 
 (defn convert
   "Performs the conversion for this database version"

--- a/src/main/conversions/v2.12.0/c2_12_0_2017051001.clj
+++ b/src/main/conversions/v2.12.0/c2_12_0_2017051001.clj
@@ -1,0 +1,21 @@
+(ns facepalm.c2-12-0-2017051001
+  (:use [kameleon.sql-reader :only [exec-sql-statement]])
+  (:require [korma.core :as sql]))
+
+(def ^:private version
+  "The destination database version"
+  "2.12.0:20170510.01")
+
+(defn- add-container-images-deprecated-column
+  []
+  (println "\t* add deprecated column to container_images table...")
+  (exec-sql-statement "ALTER TABLE ONLY container_images ADD COLUMN deprecated BOOLEAN NOT NULL DEFAULT FALSE")
+  (sql/update :container_images
+              (sql/set-fields {:deprecated true})
+              (sql/where {:name "docker.cyverse.org/backwards-compat"})))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-container-images-deprecated-column))

--- a/src/main/data/21_internal_apps.sql
+++ b/src/main/data/21_internal_apps.sql
@@ -212,8 +212,9 @@ INSERT INTO container_images (id, "name", tag, url) VALUES
      'latest',
      'https://registry.hub.docker.com/u/discoenv/curl-wrapper/');
 
-INSERT INTO container_images (id, "name", tag, url) VALUES
+INSERT INTO container_images (id, deprecated, "name", tag, url) VALUES
     ('fc210a84-f7cd-4067-939c-a68ec3e3bd2b',
+     TRUE,
      'docker.cyverse.org/backwards-compat',
      'latest',
      'https://registry.hub.docker.com/u/discoenv/backwards-compat');

--- a/src/main/data/21_internal_apps.sql
+++ b/src/main/data/21_internal_apps.sql
@@ -214,7 +214,7 @@ INSERT INTO container_images (id, "name", tag, url) VALUES
 
 INSERT INTO container_images (id, "name", tag, url) VALUES
     ('fc210a84-f7cd-4067-939c-a68ec3e3bd2b',
-     'gims.iplantcollaborative.org:5000/backwards-compat',
+     'docker.cyverse.org/backwards-compat',
      'latest',
      'https://registry.hub.docker.com/u/discoenv/backwards-compat');
 
@@ -257,7 +257,7 @@ UPDATE ONLY tools
    SET container_images_id = '15959300-b972-4571-ace2-081af0909599'
  WHERE id = '85cf7a33-386b-46fe-87c7-8c9d59972624';
 
--- Everything else should use the discoenv/backwards-compat:latest container.
+-- Everything else should use the docker.cyverse.org/backwards-compat:latest container.
 UPDATE ONLY tools
    SET container_images_id = 'fc210a84-f7cd-4067-939c-a68ec3e3bd2b'
  WHERE container_images_id IS NULL;

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -85,3 +85,4 @@ INSERT INTO version (version) VALUES ('2.10.0:20161205.01');
 INSERT INTO version (version) VALUES ('2.10.0:20161214.01');
 INSERT INTO version (version) VALUES ('2.12.0:20170428.01');
 INSERT INTO version (version) VALUES ('2.12.0:20170508.01');
+INSERT INTO version (version) VALUES ('2.12.0:20170510.01');

--- a/src/main/tables/70_container_images.sql
+++ b/src/main/tables/70_container_images.sql
@@ -8,5 +8,6 @@ CREATE TABLE container_images (
   name text NOT NULL, -- name used to indicate which image to pull down. Could be a UUID, but don't do that.
   tag text NOT NULL,  -- tag used to pull down an image. We'll default it to 'latest'
   url text,           -- URL containing more information about the image (ex: docker hub URL)
+  deprecated boolean NOT NULL DEFAULT FALSE,  -- flag indicating if tools using this image should be used in new apps.
   unique (name, tag)
 );


### PR DESCRIPTION
Adds a conversion for adding the `deprecated` column to the `container_images` table.
This column will be used as a flag indicating if tools using a Docker image at a specific name+tag should be used in new apps.