### PR TITLE
CORE-9193: added osg_image_path to the uniqueness constraint for cont…

### DIFF
--- a/src/main/conversions/v2.20.0/c2_20_0_2018032601.clj
+++ b/src/main/conversions/v2.20.0/c2_20_0_2018032601.clj
@@ -13,8 +13,26 @@
    "ALTER TABLE ONLY container_images
     ADD COLUMN osg_image_path text"))
 
+(defn- drop-container-images-name-tag-key
+  "Removes the container_images_name_tag_key index from the database."
+  []
+  (println "\t* dropping the uniqueness constraint for image name and tag in the container_images table.")
+  (exec-sql-statement
+   "ALTER TABLE ONLY container_images
+    DROP CONSTRAINT container_images_name_tag_key"))
+
+(defn- add-container-images-osg-image-path-key
+  "Adds the container_images_name_tag_osg_image_path_key index to the database."
+  []
+  (println "\t* adding a uniqueness constraint on image name, tag and OSG image path to the container_images table.")
+  (exec-sql-statement
+   "ALTER TABLE ONLY container_images
+    ADD CONSTRAINT container_images_name_tag_osg_image_path_key UNIQUE (name, tag, osg_image_path)"))
+
 (defn convert
   "Performs the conversion for this database version."
   []
   (println "Performing the conversion for" version)
-  (add-osg-image-path-column))
+  (add-osg-image-path-column)
+  (drop-container-images-name-tag-key)
+  (add-container-images-osg-image-path-key))

--- a/src/main/tables/70_container_images.sql
+++ b/src/main/tables/70_container_images.sql
@@ -10,5 +10,5 @@ CREATE TABLE container_images (
   url text,           -- URL containing more information about the image (ex: docker hub URL)
   deprecated boolean NOT NULL DEFAULT FALSE,  -- flag indicating if tools using this image should be used in new apps.
   osg_image_path text, -- the path to the Singularity image in OSG's CVM-FS repository if available.
-  unique (name, tag)
+  unique (name, tag, osg_image_path)
 );


### PR DESCRIPTION
…ainer_images

I realized after the fact that `osg_image_path` needs to be added to the uniqueness constraint. Otherwise, we might end up inadvertently making existing tools eligible for OSG. For example, this could happen if an existing container image that is already used elsewhere is reused in a new tool and an OSG image path is added to it later.
