### PR TITLE
Changes for interactive apps

### DIFF
--- a/src/main/constraints/83_container_ports.sql
+++ b/src/main/constraints/83_container_ports.sql
@@ -1,0 +1,10 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY container_ports
+    ADD CONSTRAINT container_ports_id_pkey
+    PRIMARY KEY(id);
+
+ALTER TABLE ONLY container_ports
+    ADD CONSTRAINT container_ports_container_settings_id_fkey
+    FOREIGN KEY(container_settings_id)
+    REFERENCES container_settings(id) ON DELETE CASCADE;

--- a/src/main/constraints/84_interapps_proxy_settings.sql
+++ b/src/main/constraints/84_interapps_proxy_settings.sql
@@ -1,0 +1,10 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY interactive_apps_proxy_settings
+    ADD CONSTRAINT interactive_apps_proxy_settings_id_pkey
+    PRIMARY KEY(id);
+
+ALTER TABLE ONLY interactive_apps_proxy_settings
+    ADD CONSTRAINT interactive_apps_proxy_settings_container_settings_id_fkey
+    FOREIGN KEY(container_settings_id)
+    REFERENCES container_settings(id) ON DELETE CASCADE;

--- a/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
+++ b/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
@@ -10,7 +10,7 @@
   []
   (exec-sql-statement
    "ALTER TABLE ONLY tools
-    ADD COLUMN interactive NOT NULL DEFAULT FALSE"))
+    ADD COLUMN interactive boolean NOT NULL DEFAULT FALSE"))
 
 (defn- create-container-ports-table
   "Adds the container_ports table to the database"
@@ -22,4 +22,4 @@
   []
   (println "Performing the conversion for" version)
   (add-interactive-column)
-  (craete-container-ports-table))
+  (create-container-ports-table))

--- a/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
+++ b/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
@@ -1,0 +1,25 @@
+(ns facepalm.c2-21-0-2018042601
+  (:use [kameleon.sql-reader :only [load-sql-file exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version."
+  "2.21.0:20180426.01")
+
+(defn- add-interactive-column
+  "Adds the interactive column to the tools table"
+  []
+  (exec-sql-statement
+   "ALTER TABLE ONLY tools
+    ADD COLUMN interactive NOT NULL DEFAULT FALSE"))
+
+(defn- create-container-ports-table
+  "Adds the container_ports table to the database"
+  []
+  (load-sql-file "tables/83_container_ports.sql"))
+
+(defn convert
+  "Performs the conversion for this database version."
+  []
+  (println "Performing the conversion for" version)
+  (add-interactive-column)
+  (craete-container-ports-table))

--- a/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
+++ b/src/main/conversions/v2.21.0/c2_21_0_2018042601.clj
@@ -15,11 +15,19 @@
 (defn- create-container-ports-table
   "Adds the container_ports table to the database"
   []
-  (load-sql-file "tables/83_container_ports.sql"))
+  (load-sql-file "tables/83_container_ports.sql")
+  (load-sql-file "constraints/83_container_ports.sql"))
+
+(defn- create-interapps-proxy-settings-table
+  "Adds the interactive_apps_proxy_settings table to the database"
+  []
+  (load-sql-file "tables/84_interapps_proxy_settings.sql")
+  (load-sql-file "constraints/84_interapps_proxy_settings.sql"))
 
 (defn convert
   "Performs the conversion for this database version."
   []
   (println "Performing the conversion for" version)
   (add-interactive-column)
-  (create-container-ports-table))
+  (create-container-ports-table)
+  (create-interapps-proxy-settings-table))

--- a/src/main/tables/03_tools.sql
+++ b/src/main/tables/03_tools.sql
@@ -14,5 +14,6 @@ CREATE TABLE tools (
     integration_data_id uuid NOT NULL,
     container_images_id uuid,
     time_limit_seconds integer NOT NULL DEFAULT 0,
-    restricted boolean NOT NULL DEFAULT FALSE
+    restricted boolean NOT NULL DEFAULT FALSE,
+    interactive boolean NOT NULL DEFAULT FALSE
 );

--- a/src/main/tables/83_container_ports.sql
+++ b/src/main/tables/83_container_ports.sql
@@ -5,7 +5,7 @@ SET search_path = public, pg_catalog;
 
 CREATE TABLE container_ports (
   -- primary key
-  id uuid UNIQUE NOT NULL uuid_generate_v1(),
+  id uuid UNIQUE NOT NULL DEFAULT uuid_generate_v1(),
 
   -- The foreign key into the container_settings table
   container_settings_id uuid NOT NULL,

--- a/src/main/tables/83_container_ports.sql
+++ b/src/main/tables/83_container_ports.sql
@@ -1,0 +1,21 @@
+SET search_path = public, pg_catalog;
+
+-- Contains the the port information for a tool's container. This is used for
+-- interactive apps.
+
+CREATE TABLE container_ports (
+  -- primary key
+  id uuid UNIQUE NOT NULL uuid_generate_v1(),
+
+  -- The foreign key into the container_settings table
+  container_settings_id uuid NOT NULL,
+
+  -- The port on the host to bind to the container. Can be null, which should
+  -- cause a random port to be allocated.
+  host_port integer,
+
+  -- The port that the container should be listening on. Should not be null.
+  container_port integer NOT NULL,
+
+  bind_to_host boolean NOT NULL DEFAULT FALSE
+);

--- a/src/main/tables/84_interapps_proxy_settings.sql
+++ b/src/main/tables/84_interapps_proxy_settings.sql
@@ -1,0 +1,43 @@
+SET search_path = public, pg_catalog;
+
+-- Contains the proxy settings for the interactive apps that run on the cluster.
+
+CREATE TABLE interactive_apps_proxy_settings (
+  -- primary key
+  id uuid NOT NULL DEFAULT uuid_generate_v1(),
+
+  -- foreign key into the container_settings table
+  container_settings_id uuid NOT NULL,
+
+  -- Docker image to pull that contains the proxy.
+  image text NOT NULL,
+
+  -- The name that should be given to the docker container created for the proxy.
+  name text NOT NULL,
+
+  -- The externally facing URL that users hit to access the interactive app.
+  -- This is nullable so that the database can override the default behavior,
+  -- which is to generate the URL from an configuration setting and the analysis
+  -- UUID.
+  frontend_url text,
+
+  -- The base CAS URL that the proxy should use to authenticate users. This is
+  -- nullable so that the database can optionally override the default behavior,
+  -- which is to use the URL provided in a configuration setting.
+  cas_url text,
+
+  -- When combined with the cas_url field, this creates the URL that CAS tickets
+  -- are validated against. This is nullable so that the database can optionally
+  -- override the default behavior, which is to use a configuration setting.
+  cas_validate text,
+
+  -- The path to the SSL cert to use on the HTCondor nodes. This is nullable for
+  -- now, since we want the database to override the setting provided in the
+  -- configuration file.
+  ssl_cert_path text,
+
+  -- The path to the SSL key to use on the HTCondor nodes. This is nullable for
+  -- now, since we want the database to override the setting provided in the
+  -- configuration file.
+  ssl_key_path text
+)


### PR DESCRIPTION
Adds the interactive column to the tools table.

Adds the container_ports table, which contains the settings we might need to allow interactive apps to be accessible to the outside world. For now only the container_port column is really needed, but future iterations of the interactive apps feature may need the other columns as well.

Adds the interactive_apps_proxy_settings table, which contains the settings needed to configure cas-proxy for interactive apps. 

For the first release we'll be only supporting a single tool per-job as interactive, but future releases could enable multiple steps being interactive. That's why interactive_apps_proxy_settings joins on the container_settings table.

The apps service has not been changed to use anything from this pull request yet.

These changes were checked against the discoenv/unittest-dedb image, which shook out a few issues that were fixed in the last commit.