### PR TITLE
Add skip_tmp_mount column to container_settings table

### DIFF
--- a/src/main/conversions/v2.21.0/c2_21_0_2018051501.clj
+++ b/src/main/conversions/v2.21.0/c2_21_0_2018051501.clj
@@ -1,0 +1,19 @@
+(ns facepalm.c2-21-0-2018051501
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.21.0:20180515.01")
+
+(defn add-skip-tmp-mount-column
+  "Adds the skip_tmp_mount column to the container_settings table"
+  []
+  (exec-sql-statement
+   "ALTER TABLE ONLY container_settings
+    ADD COLUMN skip_tmp_mount bool NOT NULL DEFAULT FALSE"))
+
+(defn convert
+  "Performs the conversion for this database version."
+  []
+  (println "Performing the conversion for" version)
+  (add-skip-tmp-mount-column))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -93,3 +93,4 @@ INSERT INTO version (version) VALUES ('2.18.0:20171113.01');
 INSERT INTO version (version) VALUES ('2.20.0:20180326.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180419.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180426.01');
+INSERT INTO version (version) VALUES ('2.21.0:20180515.01');

--- a/src/main/tables/71_container_settings.sql
+++ b/src/main/tables/71_container_settings.sql
@@ -53,5 +53,10 @@ CREATE TABLE container_settings (
 
   -- The entrypoint of the running container. This will let us override a
   -- container's default entrypoint, if it has one and it's necessary.
-  entrypoint text
+  entrypoint text,
+
+  -- Whether or not to mount the /tmp directory into the container. Defaults to
+  -- false because the majority of tools won't have a problem with this, it's
+  -- just a few outliers that cause issues.
+  skip_tmp_mount bool NOT NULL DEFAULT FALSE
 );


### PR DESCRIPTION
Adds the column to the container_settings table definition and adds a conversion to have it added to an existing database. Tested against the unittest-dedb image.