### PR TITLE
Add record for the interactive tool type

### DIFF
--- a/src/main/conversions/v2.22.0/c2_22_0_2018052301.clj
+++ b/src/main/conversions/v2.22.0/c2_22_0_2018052301.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-22-0-2018052301
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.22.0:20180523.01")
+
+(defn- add-interactive-tool-type
+  "Adds a record for the interactive tool type"
+  []
+  (exec-sql-statement
+   "INSERT INTO tool_types (id, name, label, description) VALUES ('4166B913-EAFA-4731-881F-21C3751DFFBB', 'interactive', 'Interactive DE tools.', 'Interactive tools used by the Discovery Environment.' );"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Peforming the conversion for" version)
+  (add-interactive-tool-type))

--- a/src/main/data/14_tool_types.sql
+++ b/src/main/data/14_tool_types.sql
@@ -8,3 +8,6 @@ INSERT INTO tool_types (id, name, label, description)
 
 INSERT INTO tool_types (id, name, label, description, hidden)
     VALUES ( '01E14110-1420-4DE0-8A70-B0DD420F6A84', 'internal', 'Internal DE tools.', 'Tools used internally by the Discovery Environment.', true );
+
+INSERT INTO tool_types (id, name, label, description)
+    VALUES ( '4166B913-EAFA-4731-881F-21C3751DFFBB', 'interactive', 'Interactive DE tools.', 'Interactive tools used by the Discovery Environment.' );

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -94,3 +94,4 @@ INSERT INTO version (version) VALUES ('2.20.0:20180326.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180419.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180426.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180515.01');
+INSERT INTO version (version) VALUES ('2.22.0:20180523.01');


### PR DESCRIPTION
Adds a new record for interactive tools. Adds a conversion for it as well. 

Tested against the unittest-dedb container image.