### PR TITLE
Add/modify cpu core settings for containers.

### DIFF
--- a/src/main/conversions/v2.22.0/c2_22_0_2018060401.clj
+++ b/src/main/conversions/v2.22.0/c2_22_0_2018060401.clj
@@ -1,0 +1,25 @@
+(ns facepalm.c2-22-0-2018060401
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.22.0:20180604.01")
+
+(defn- alter-min-cpu-cores-column
+  "Changes the type for the container_settings.min_cpu_cores column from integer to decimal(6,3)."
+  []
+  (exec-sql-statement
+   "ALTER TABLE container_settings ALTER COLUMN min_cpu_cores TYPE decimal(6,3)"))
+
+(defn- add-max-cpu-cores-column
+  "Adds the max-cpus-cores column to the container_settings table."
+  []
+  (exec-sql-statement
+   "ALTER TABLE container_settings ADD COLUMN max_cpu_cores decimal(6,3)"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Peforming the conversion for" version)
+  (alter-min-cpu-cores-column)
+  (add-max-cpu-cores-column))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -96,3 +96,4 @@ INSERT INTO version (version) VALUES ('2.21.0:20180426.01');
 INSERT INTO version (version) VALUES ('2.21.0:20180515.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180523.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180601.01');
+INSERT INTO version (version) VALUES ('2.22.0:20180604.01');

--- a/src/main/tables/71_container_settings.sql
+++ b/src/main/tables/71_container_settings.sql
@@ -28,9 +28,13 @@ CREATE TABLE container_settings (
   -- in the Condor ClassAds and is not passed to the Docker container.
   min_memory_limit bigint,
 
-  -- The minimum number of cpu cores required to run the container. It's passed
-  -- to Docker with the --cpus command-line switch.
-  min_cpu_cores integer,
+  -- The minimum number of cpu cores required to run the container. This could
+  -- be used for job matching.
+  min_cpu_cores decimal(6,3),
+
+  -- The maximum number of cpu cores the container is allowed to use. This is
+  -- passed to the container runtime.
+  max_cpu_cores decimal(6,3),
 
   -- The minimum amount of disk space required to run the container. This does
   -- not correspond to a docker option, it's purely used for Condor job


### PR DESCRIPTION
The container_settings.max_cpu_cores field contains the maximum
allowable CPU cores for a tool. It's a numeric field since that's what
both docker and kubernetes take for their cpu limits.

The container_settings.min_cpu_cores field was changed over to a numeric
field to mirror the container_settings.max_cpu_cores field. It's
currently unused, but could be used to assist job schedulers in HTCondor
or Kubernetes.