### PR TITLE
Add the uid column to the container_settings table

### DIFF
--- a/src/main/conversions/v2.22.0/c2_22_0_2018071802.clj
+++ b/src/main/conversions/v2.22.0/c2_22_0_2018071802.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-22-0-2018071802
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.22.0:20180718.02")
+
+(defn- add-uid-column
+  "Adds the UID column to the container_settings table."
+  []
+  (exec-sql-statement
+   "ALTER TABLE container_settings ADD COLUMN uid int"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-uid-column))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -100,3 +100,4 @@ INSERT INTO version (version) VALUES ('2.22.0:20180604.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180614.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180617.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180718.01');
+INSERT INTO version (version) VALUES ('2.22.0:20180718.02');

--- a/src/main/tables/71_container_settings.sql
+++ b/src/main/tables/71_container_settings.sql
@@ -62,5 +62,12 @@ CREATE TABLE container_settings (
   -- Whether or not to mount the /tmp directory into the container. Defaults to
   -- false because the majority of tools won't have a problem with this, it's
   -- just a few outliers that cause issues.
-  skip_tmp_mount bool NOT NULL DEFAULT FALSE
+  skip_tmp_mount bool NOT NULL DEFAULT FALSE,
+
+  -- The user ID that the contained process will run as. Needs to be the actual
+  -- UID of the user created by the Dockerfile, if it exists. This isn't passed
+  -- on the command-line, but is used to make sure permissions are correct for
+  -- the working directory in the container. If it's not set, the default of 0
+  -- will be used (but not stored in the database).
+  uid int
 );


### PR DESCRIPTION
This is needed because we can't necessarily grab the UID by inspecting the image, which means we're setting permissions wrong when running interactive apps.