### PR TITLE
Add subdomain column to the jobs table

### DIFF
--- a/src/main/conversions/v2.23.0/c2_23_0_2018082801.clj
+++ b/src/main/conversions/v2.23.0/c2_23_0_2018082801.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-23-0-2018082801
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.23.0:20180828.01")
+
+(defn- add-subdomain-column
+  "Add the subdomain column to the jobs table."
+  []
+  (exec-sql-statement
+   "ALTER TABLE jobs ADD COLUMN subdomain character varying(32)"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-subdomain-column))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -102,3 +102,4 @@ INSERT INTO version (version) VALUES ('2.22.0:20180617.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180718.01');
 INSERT INTO version (version) VALUES ('2.22.0:20180718.02');
 INSERT INTO version (version) VALUES ('2.22.0:20180724.01');
+INSERT INTO version (version) VALUES ('2.23.0:20180828.01');

--- a/src/main/tables/57_jobs.sql
+++ b/src/main/tables/57_jobs.sql
@@ -20,6 +20,7 @@ CREATE TABLE jobs (
     deleted boolean DEFAULT FALSE NOT NULL,
     notify boolean DEFAULT FALSE NOT NULL,
     user_id uuid NOT NULL,
+    subdomain character varying(32),
     submission json,
     parent_id uuid
 );


### PR DESCRIPTION
We need to allow for lookups going from the VICE subdomain back to a running job.