### PR TITLE
CORE-63: add an apps_htcondor_extra table

### DIFF
--- a/src/main/constraints/00_88_apps_htcondor_extra.sql
+++ b/src/main/constraints/00_88_apps_htcondor_extra.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY apps_htcondor_extra
+    ADD CONSTRAINT apps_htcondor_extra_apps_id_pkey
+    PRIMARY KEY(apps_id);

--- a/src/main/constraints/88_apps_htcondor_extra.sql
+++ b/src/main/constraints/88_apps_htcondor_extra.sql
@@ -1,0 +1,6 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY apps_htcondor_extra
+    ADD CONSTRAINT apps_htcondor_extra_apps_id_fkey
+    FOREIGN KEY(apps_id)
+    REFERENCES apps(id) ON DELETE CASCADE;

--- a/src/main/conversions/v2.25.0/c2_25_0_2019020601.clj
+++ b/src/main/conversions/v2.25.0/c2_25_0_2019020601.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-25-0-2019020601
+  (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.25.0:20190206.01")
+
+(defn- add-apps-htcondor-extra-table
+  []
+  (load-sql-file "tables/88_apps_htcondor_extra.sql")
+  (load-sql-file "constraints/00_88_apps_htcondor_extra.sql")
+  (load-sql-file "constraints/88_apps_htcondor_extra.sql"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-apps-htcondor-extra-table))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -106,4 +106,5 @@ INSERT INTO version (version) VALUES ('2.23.0:20180828.01');
 INSERT INTO version (version) VALUES ('2.23.0:20181024.01');
 INSERT INTO version (version) VALUES ('2.24.0:20181205.01');
 INSERT INTO version (version) VALUES ('2.24.0:20190114.01');
+INSERT INTO version (version) VALUES ('2.25.0:20190206.01');
 INSERT INTO version (version) VALUES ('2.25.0:20190212.01');

--- a/src/main/tables/88_apps_htcondor_extra.sql
+++ b/src/main/tables/88_apps_htcondor_extra.sql
@@ -1,0 +1,9 @@
+SET search_path = public, pg_catalog;
+
+-- Contains additional information to be added to htcondor jobs for special cases.
+
+CREATE TABLE apps_htcondor_extra (
+  -- primary key
+  apps_id uuid NOT NULL,
+  extra_requirements text NOT NULL
+);


### PR DESCRIPTION
This will store extra things to be added to the job requirements at the
app level. This should only be editable by administrators, and will be
joined to the requirements we manage manually by way of an &&.

I pretty much just copied another conversion, so hopefully I didn't do something wrong there, heh.