### PR TITLE
Minor conversion script changes.

### DIFF
--- a/src/main/conversions/v2.25.0/c2_25_0_2019022601.clj
+++ b/src/main/conversions/v2.25.0/c2_25_0_2019022601.clj
@@ -10,15 +10,15 @@
   (load-sql-file "tables/89_submissions.sql")
   (load-sql-file "constraints/00_89_submissions_pkey.sql"))
 
-(defn- create-badges-table
+(defn- create-quick-launches-table
   []
-  (load-sql-file "tables/90_badges.sql")
-  (load-sql-file "constraints/00_90_badges_pkey.sql")
-  (load-sql-file "constraints/90_badges.sql"))
+  (load-sql-file "tables/90_quick_launches.sql")
+  (load-sql-file "constraints/00_90_quick_launches_pkey.sql")
+  (load-sql-file "constraints/90_quick_launches.sql"))
 
 (defn convert
   "Performs the conversion for this database version"
   []
   (println "Performing the conversion for" version)
   (create-submissions-table)
-  (create-badges-table))
+  (create-quick-launches-table))

--- a/src/main/conversions/v2.26.0/c2_26_0_2019031801.clj
+++ b/src/main/conversions/v2.26.0/c2_26_0_2019031801.clj
@@ -25,7 +25,7 @@
    "ALTER TABLE IF EXISTS ONLY badges
     RENAME CONSTRAINT badges_user_id_fkey TO quick_launches_creator_fkey;")
   (exec-sql-statement
-   "ALTER TABLE ONLY badges
+   "ALTER TABLE IF EXISTS ONLY badges
     ADD CONSTRAINT quick_launches_app_id_fkey FOREIGN KEY (app_id) REFERENCES apps(id);")
   (exec-sql-statement
    "ALTER TABLE IF EXISTS ONLY badges RENAME TO quick_launches;"))


### PR DESCRIPTION
One of the conversion scripts referenced a file that no longer exists, which prevented the VerSSA database from being updated. In this case, the table was renamed, so I was able to modify the conversion script to reference the new table creation files instead. A subsequent conversion script also needed to have one SQL statement updated so that it does nothing if the old table doesn't exist.

I tested this by running the conversion against the VerSSA database.
