### PR TITLE
Add async tasks tables

### DIFF
--- a/src/main/constraints/00_95_async_tasks.sql
+++ b/src/main/constraints/00_95_async_tasks.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY async_tasks
+    ADD CONSTRAINT async_tasks_pkey
+    PRIMARY KEY(id);

--- a/src/main/constraints/00_96_async_task_status.sql
+++ b/src/main/constraints/00_96_async_task_status.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY async_task_status
+    ADD CONSTRAINT async_task_status_pkey
+    PRIMARY KEY(async_task_id, status, created_date);

--- a/src/main/constraints/00_97_async_task_behavior.sql
+++ b/src/main/constraints/00_97_async_task_behavior.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY async_task_behavior
+    ADD CONSTRAINT async_task_behavior_pkey
+    PRIMARY KEY(async_task_id, behavior_type);

--- a/src/main/constraints/95_async_tasks.sql
+++ b/src/main/constraints/95_async_tasks.sql
@@ -1,0 +1,11 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE async_task_status
+    ADD CONSTRAINT async_task_status_async_task_id_fkey
+    FOREIGN KEY (async_task_id)
+    REFERENCES async_tasks(id) ON DELETE CASCADE;
+
+ALTER TABLE async_task_behavior
+    ADD CONSTRAINT async_task_behavior_async_task_id_fkey
+    FOREIGN KEY (async_task_id)
+    REFERENCES async_tasks(id) ON DELETE CASCADE;

--- a/src/main/constraints/96_async_task_status.sql
+++ b/src/main/constraints/96_async_task_status.sql
@@ -4,8 +4,3 @@ ALTER TABLE async_task_status
     ADD CONSTRAINT async_task_status_async_task_id_fkey
     FOREIGN KEY (async_task_id)
     REFERENCES async_tasks(id) ON DELETE CASCADE;
-
-ALTER TABLE async_task_behavior
-    ADD CONSTRAINT async_task_behavior_async_task_id_fkey
-    FOREIGN KEY (async_task_id)
-    REFERENCES async_tasks(id) ON DELETE CASCADE;

--- a/src/main/constraints/97_async_task_behavior.sql
+++ b/src/main/constraints/97_async_task_behavior.sql
@@ -1,0 +1,6 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE async_task_behavior
+    ADD CONSTRAINT async_task_behavior_async_task_id_fkey
+    FOREIGN KEY (async_task_id)
+    REFERENCES async_tasks(id) ON DELETE CASCADE;

--- a/src/main/conversions/v2.28.0/c2_28_0_2019081501.clj
+++ b/src/main/conversions/v2.28.0/c2_28_0_2019081501.clj
@@ -1,0 +1,24 @@
+(ns facepalm.c2-28-0-2019081501
+  (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.28.0:20190815.01")
+
+(defn- add-async-tasks-tables
+  []
+  (load-sql-file "tables/95_async_tasks.sql")
+  (load-sql-file "constraints/00_95_async_tasks.sql")
+
+  (load-sql-file "tables/96_async_task_status.sql")
+  (load-sql-file "constraints/00_96_async_task_status.sql")
+
+  (load-sql-file "tables/97_async_task_behavior.sql")
+  (load-sql-file "constraints/00_97_async_task_behavior.sql")
+
+  (load-sql-file "constraints/95_async_tasks.sql"))
+
+(defn convert
+  []
+  (println "Performing the conversion to" version)
+  (add-async-tasks-tables))

--- a/src/main/conversions/v2.28.0/c2_28_0_2019081501.clj
+++ b/src/main/conversions/v2.28.0/c2_28_0_2019081501.clj
@@ -16,7 +16,8 @@
   (load-sql-file "tables/97_async_task_behavior.sql")
   (load-sql-file "constraints/00_97_async_task_behavior.sql")
 
-  (load-sql-file "constraints/95_async_tasks.sql"))
+  (load-sql-file "constraints/96_async_task_status.sql")
+  (load-sql-file "constraints/97_async_task_behavior.sql"))
 
 (defn convert
   []

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -112,3 +112,4 @@ INSERT INTO version (version) VALUES ('2.25.0:20190226.01');
 INSERT INTO version (version) VALUES ('2.26.0:20190318.01');
 INSERT INTO version (version) VALUES ('2.26.0:20190409.01');
 INSERT INTO version (version) VALUES ('2.27.0:20190528.01');
+INSERT INTO version (version) VALUES ('2.28.0:20190815.01');

--- a/src/main/tables/95_async_tasks.sql
+++ b/src/main/tables/95_async_tasks.sql
@@ -12,3 +12,10 @@ CREATE TABLE async_tasks (
     end_date timestamp
 );
 
+--
+-- Indices to speed up listing and filtering
+--
+CREATE INDEX async_tasks_type_index ON async_tasks(type);
+CREATE INDEX async_tasks_username_index ON async_tasks(username);
+CREATE INDEX async_tasks_start_date_index ON async_tasks(start_date);
+CREATE INDEX async_tasks_end_date_index ON async_tasks(end_date);

--- a/src/main/tables/95_async_tasks.sql
+++ b/src/main/tables/95_async_tasks.sql
@@ -1,0 +1,14 @@
+SET search_path = public, pg_catalog;
+
+--
+-- async_tasks table
+--
+CREATE TABLE async_tasks (
+    id uuid NOT NULL DEFAULT uuid_generate_v1(),
+    type text NOT NULL,
+    username text,
+    data json,
+    start_date timestamp,
+    end_date timestamp
+);
+

--- a/src/main/tables/96_async_task_status.sql
+++ b/src/main/tables/96_async_task_status.sql
@@ -1,0 +1,12 @@
+SET search_path = public, pg_catalog;
+
+--
+-- async_task_status table
+--
+CREATE TABLE async_task_status (
+	async_task_id uuid NOT NULL,
+	status text NOT NULL,
+	created_date timestamp NOT NULL
+);
+
+

--- a/src/main/tables/96_async_task_status.sql
+++ b/src/main/tables/96_async_task_status.sql
@@ -9,4 +9,7 @@ CREATE TABLE async_task_status (
 	created_date timestamp NOT NULL
 );
 
-
+--
+-- Index to speed up listing in sorted date order
+--
+CREATE INDEX async_task_status_id_date_index ON async_tasks(async_task_id, created_date);

--- a/src/main/tables/97_async_task_behavior.sql
+++ b/src/main/tables/97_async_task_behavior.sql
@@ -8,5 +8,3 @@ CREATE TABLE async_task_behavior (
 	behavior_type text NOT NULL,
 	data json
 );
-
-

--- a/src/main/tables/97_async_task_behavior.sql
+++ b/src/main/tables/97_async_task_behavior.sql
@@ -1,0 +1,12 @@
+SET search_path = public, pg_catalog;
+
+--
+-- async_task_behavior table
+--
+CREATE TABLE async_task_behavior (
+	async_task_id uuid NOT NULL,
+	behavior_type text NOT NULL,
+	data json
+);
+
+


### PR DESCRIPTION
Hopefully I haven't missed anything. Been a while since I had to write a DB conversion.

This should add the three tables we need for basic async task support: one for the task itself, one that records status updates for tasks, and one that tracks custom behaviors the service can use (e.g. information about how to start processing, timeouts before trying again to trigger the processing, any notifications, etc., are all things that could use this system eventually -- to start probably only the "how to trigger processing of the task" behavior will be used, but leaving room for growth).