### PR TITLE
Add the tools.gpu_enabled column.

### DIFF
--- a/src/main/conversions/v2.30.0/c2_30_0_2019111801.clj
+++ b/src/main/conversions/v2.30.0/c2_30_0_2019111801.clj
@@ -1,0 +1,17 @@
+(ns facepalm.c2-30-0-2019111801
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.30.0:20191118.01")
+
+(defn- add-gpu-enabled-column
+  []
+  (exec-sql-statement
+   "ALTER TABLE tools ADD COLUMN gpu_enabled boolean NOT NULL DEFAULT FALSE"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-gpu-enabled-column))

--- a/src/main/data/99_version.sql
+++ b/src/main/data/99_version.sql
@@ -114,3 +114,4 @@ INSERT INTO version (version) VALUES ('2.26.0:20190409.01');
 INSERT INTO version (version) VALUES ('2.27.0:20190528.01');
 INSERT INTO version (version) VALUES ('2.28.0:20190815.01');
 INSERT INTO version (version) VALUES ('2.29.0:20190917.01');
+INSERT INTO version (version) VALUES ('2.30.0:20191118.01');

--- a/src/main/tables/03_tools.sql
+++ b/src/main/tables/03_tools.sql
@@ -15,5 +15,6 @@ CREATE TABLE tools (
     container_images_id uuid,
     time_limit_seconds integer NOT NULL DEFAULT 0,
     restricted boolean NOT NULL DEFAULT FALSE,
-    interactive boolean NOT NULL DEFAULT FALSE
+    interactive boolean NOT NULL DEFAULT FALSE,
+    gpu_enabled boolean NOT NULL DEFAULT FALSE
 );


### PR DESCRIPTION
Allows us to track whether a tool is can use a GPU or not. It's here instead of in the container_settings table because it's possible for a non-container tool to access GPUs as well.

Used version 2.30.0 in the conversion because we skipped the release last month.