### PR TITLE
Add notif_statuses table

### DIFF
--- a/src/main/constraints/000_103_notif_statuses.sql
+++ b/src/main/constraints/000_103_notif_statuses.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY notif_statuses 
+    ADD CONSTRAINT notif_statuses_pkey
+    PRIMARY KEY(id);

--- a/src/main/conversions/v2.32.0/c2_32_0_2020040201.clj
+++ b/src/main/conversions/v2.32.0/c2_32_0_2020040201.clj
@@ -5,7 +5,7 @@
   "The destination database version"
   "2.32.0:20200402.01")
 
-(def- add-notif-statuses-table
+(defn- add-notif-statuses-table
   "Adds the notif_statuses table."
   []
   (load-sql-file "tables/103_notif_statuses.sql")

--- a/src/main/conversions/v2.32.0/c2_32_0_2020040201.clj
+++ b/src/main/conversions/v2.32.0/c2_32_0_2020040201.clj
@@ -1,0 +1,18 @@
+(ns facepalm.c2-32-0-2020040201
+  (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.32.0:20200402.01")
+
+(def- add-notif-statuses-table
+  "Adds the notif_statuses table."
+  []
+  (load-sql-file "tables/103_notif_statuses.sql")
+  (load-sql-file "constraints/000_103_notif_statuses.sql"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-notif-statuses-table))

--- a/src/main/data/999_version.sql
+++ b/src/main/data/999_version.sql
@@ -118,3 +118,4 @@ INSERT INTO version (version) VALUES ('2.30.0:20191118.01');
 INSERT INTO version (version) VALUES ('2.30.0:20191121.01');
 INSERT INTO version (version) VALUES ('2.31.0:20191212.01');
 INSERT INTO version (version) VALUES ('2.32.0:20200319.01');
+INSERT INTO version (version) VALUES ('2.32.0:20200402.01');

--- a/src/main/tables/103_notif_statuses.sql
+++ b/src/main/tables/103_notif_statuses.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS notif_statuses (
 	hour_warning_sent BOOL NOT NULL DEFAULT false,
 	day_warning_sent BOOL NOT NULL DEFAULT false,
 	kill_warning_sent BOOL NOT NULL DEFAULT false,
-    hour_warning_failure_count INT NOT NULL DEFAULT 0,
-    day_warning_failure_count INT NOT NULL DEFAULT 0,
-    kill_warning_failure_count INT NOT NULL DEFAULT 0
+	hour_warning_failure_count INT NOT NULL DEFAULT 0,
+	day_warning_failure_count INT NOT NULL DEFAULT 0,
+	kill_warning_failure_count INT NOT NULL DEFAULT 0
 );

--- a/src/main/tables/103_notif_statuses.sql
+++ b/src/main/tables/103_notif_statuses.sql
@@ -1,0 +1,16 @@
+SET search_path = public, pg_catalog;
+
+--
+-- Tracks warning and cancellation notifications for jobs.
+--
+CREATE TABLE IF NOT EXISTS notif_statuses (
+	id UUID UNIQUE NOT NULL DEFAULT uuid_generate_v1(),
+	analysis_id UUID UNIQUE NOT NULL,
+	external_id UUID UNIQUE NOT NULL,
+	hour_warning_sent BOOL NOT NULL DEFAULT false,
+	day_warning_sent BOOL NOT NULL DEFAULT false,
+	kill_warning_sent BOOL NOT NULL DEFAULT false,
+    hour_warning_failure_count INT NOT NULL DEFAULT 0,
+    day_warning_failure_count INT NOT NULL DEFAULT 0,
+    kill_warning_failure_count INT NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
Tested with unittest-dedb.

Adds the notif_statuses table, which timelord uses to track whether notifications have been sent to warn users that their analysis is going to be terminated in the future. Originally in redis, then in cockroach-db, now in the DE database.

A new version was added to the version table.