### PR TITLE
Add a 'detail' column to async_task_status table

### DIFF
--- a/src/main/conversions/v2.33.0/c2_33_0_2020042001.clj
+++ b/src/main/conversions/v2.33.0/c2_33_0_2020042001.clj
@@ -1,0 +1,17 @@
+(ns facepalm.c2-33-0-2020042001
+  (:use [kameleon.sql-reader :only [exec-sql-statement]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.33.0:20200420.01")
+
+(defn- add-async-task-status-detail-column
+  []
+  (exec-sql-statement
+   "ALTER TABLE async_task_status ADD COLUMN detail text"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-async-task-status-detail-column))

--- a/src/main/data/999_version.sql
+++ b/src/main/data/999_version.sql
@@ -119,3 +119,4 @@ INSERT INTO version (version) VALUES ('2.30.0:20191121.01');
 INSERT INTO version (version) VALUES ('2.31.0:20191212.01');
 INSERT INTO version (version) VALUES ('2.32.0:20200319.01');
 INSERT INTO version (version) VALUES ('2.32.0:20200402.01');
+INSERT INTO version (version) VALUES ('2.33.0:20200420.01');

--- a/src/main/tables/096_async_task_status.sql
+++ b/src/main/tables/096_async_task_status.sql
@@ -6,6 +6,7 @@ SET search_path = public, pg_catalog;
 CREATE TABLE async_task_status (
 	async_task_id uuid NOT NULL,
 	status text NOT NULL,
+	detail text,
 	created_date timestamp NOT NULL
 );
 


### PR DESCRIPTION
to be used for non-filtering-relevant details on a given status change

fairly straightforward I think, putting up a PR because I'm feeling tired and like I might have missed something

The main point of this (and corresponding async-tasks changes) is that then we don't need to shove extra info into the status type name itself, which makes the cardinality of different status types much smaller and thus more useful for filtering tasks by status, including for things like the [statuschangetimeout behavior](https://github.com/cyverse-de/async-tasks/pull/2)