### PR TITLE
Add bags table and constraints

### DIFF
--- a/src/main/constraints/000_104_bags.sql
+++ b/src/main/constraints/000_104_bags.sql
@@ -1,0 +1,5 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY bags
+    ADD CONSTRAINT bags_pkey
+    PRIMARY KEY(id);

--- a/src/main/constraints/104_bags.sql
+++ b/src/main/constraints/104_bags.sql
@@ -1,0 +1,6 @@
+SET search_path = public, pg_catalog;
+
+ALTER TABLE bags
+    ADD CONSTRAINT bags_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id) ON DELETE CASCADE;

--- a/src/main/conversions/v2.34.0/c2_34_0_2020082002.clj
+++ b/src/main/conversions/v2.34.0/c2_34_0_2020082002.clj
@@ -1,4 +1,4 @@
-(ns facepalm.c2-34-0-2020082002.clj
+(ns facepalm.c2-34-0-2020082002
   (:use [kameleon.sql-reader :only [load-sql-file]]))
 
 (def ^:private version

--- a/src/main/conversions/v2.34.0/c2_34_0_2020082002.clj
+++ b/src/main/conversions/v2.34.0/c2_34_0_2020082002.clj
@@ -1,0 +1,20 @@
+(ns facepalm.c2-34-0-2020082002.clj
+  (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination database version"
+  "2.32.0:20200820.02")
+
+(defn- add-bags-table
+  "Adds the bags table and its constraints"
+  []
+  (mapv load-sql-file
+        ["tables/104_bags.sql"
+         "constraints/000_104_bags.sql"
+         "constraints/104_bags.sql"]))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-bags-table))

--- a/src/main/tables/104_bags.sql
+++ b/src/main/tables/104_bags.sql
@@ -1,0 +1,13 @@
+SET search_path = public, pg_catalog;
+
+--
+-- Tracks user bags.
+--
+CREATE TABLE IF NOT EXISTS bags (
+    id UUID UNIQUE NOT NULL DEFAULT uuid_generate_v1(),
+
+    -- Not unique, a user may have multiple bags.
+    user_id UUID NOT NULL, 
+
+    contents json NOT NULL
+);


### PR DESCRIPTION
Adds the bags table to the database, along with its constraints and a new conversion. Multiple bags should be allowable per-user, and the contents of the bags will effectively be managed by the frontend since it's supposed to be a cart-like implementation.