### PR TITLE
CORE-1143: added a new index to the jobs table

### DIFF
--- a/src/main/constraints/005_apps.sql
+++ b/src/main/constraints/005_apps.sql
@@ -1,0 +1,5 @@
+--
+-- Name: jobs_app_id_start_date; Type: INDEX; Schema: public; Owner: de;
+--
+CREATE INDEX IF NOT EXISTS jobs_app_id_start_date
+ON jobs(app_id, start_date);

--- a/src/main/conversions/v2.35.0/c2_35_0_2020102301.clj
+++ b/src/main/conversions/v2.35.0/c2_35_0_2020102301.clj
@@ -1,0 +1,16 @@
+(ns facepalm.c2-35-0-2020102301
+  (:use [kameleon.sql-reader :only [load-sql-file]]))
+
+(def ^:private version
+  "The destination databse version."
+  "2.35.0:20201023.01")
+
+(defn- add-jobs-app-id-start-date-index
+  []
+  (load-sql-file "constraints/005_apps.sql"))
+
+(defn convert
+  "Performs the conversion for this database version"
+  []
+  (println "Performing the conversion for" version)
+  (add-jobs-app-id-start-date-index))

--- a/src/main/data/999_version.sql
+++ b/src/main/data/999_version.sql
@@ -125,3 +125,4 @@ INSERT INTO version (version) VALUES ('2.34.0:20200731.01');
 INSERT INTO version (version) VALUES ('2.34.0:20200820.01');
 INSERT INTO version (version) VALUES ('2.34.0:20200820.02');
 INSERT INTO version (version) VALUES ('2.34.0:20200902.01');
+INSERT INTO version (version) VALUES ('2.35.0:20201023.01');


### PR DESCRIPTION
The query to display the most recently executed app had been taking about 1.5 seconds before this index was added. After adding the index, it took a little less than 0.9 seconds. We need to get distinct app IDs, so sorting the most recent jobs by start date alone isn't quite enough to do what we need.

Edit: here's the toy query that I've been using for testing:

``` sql
SELECT DISTINCT id, name FROM (
    SELECT a.id, a.name, j.start_date FROM jobs j
    JOIN apps a ON CAST(a.id AS text) = j.app_id
    WHERE a.id = ANY ($1)
    ORDER BY j.start_date DESC
) AS recent_apps
LIMIT 25;
```

Since I want to obtain a listing of distinct apps, I'm using the inner query to get the list of jobs sorted in descending order by start date, and the outer query to extract only distinct apps from that result set. If you have a suggestion for a better way to do this, I'd like to know about it.

Here's the link to the query plan: https://explain.depesz.com/s/Kn9k

Edit: I was able to speed up the query a little bit using an aggregate to get only the maximum start date for each app ID:

``` sql
SELECT DISTINCT
    a.id,
    a.name,
    max(j.start_date) AS most_recent_start_date
FROM jobs j
JOIN apps a on CAST(a.id AS text) = j.app_id
WHERE j.app_id = ANY ($1)
GROUP BY a.id, a.name
ORDER BY most_recent_start_date DESC
LIMIT 25
```

Here's the query plan for that one: https://explain.depesz.com/s/lcrH

Another way to speed up the query was to omit jobs that were launched before some set time window. For example, apps that were most recently launched more than a month ago probably won't show up in the list of the 25 most recently launched apps anyway. (And even if they do show up on that list, I'm not sure that they'd be of all that much interest to users who want to know what the trending apps are at the moment.)